### PR TITLE
TASK: Add linux build target

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
     main: ./main.go
     goos:
       - darwin
+      - linux
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
I want to use drydock on linux. Tested locally on linux with `goreleaser release --snapshot`.
